### PR TITLE
[Optimization] Reduce temporary objects and time complexity of I/O utils

### DIFF
--- a/src/main/java/xueli/utils/io/Files.java
+++ b/src/main/java/xueli/utils/io/Files.java
@@ -14,6 +14,7 @@ import java.io.ObjectOutputStream;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
 import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
@@ -73,14 +74,19 @@ public class Files {
 		return data;
 	}
 
-	public static ArrayList<File> getAllFiles(File file) {
-		ArrayList<File> files = new ArrayList<>();
+	public static LinkedList<File> getAllFiles(File file) {
+		LinkedList<File> files = new LinkedList<>();
 
 		if (file.isDirectory()) {
 			File[] allFiles = file.listFiles();
 			for (int i = 0; i < allFiles.length; i++) {
 				File f = allFiles[i];
-				files.addAll(getAllFiles(f));
+				if(f.isFile()) {
+					files.add(f);
+					continue;
+				}
+				
+				LinkedListSplicer.splice(files, getAllFiles(f));
 
 			}
 
@@ -92,7 +98,7 @@ public class Files {
 		return files;
 	}
 
-	public static ArrayList<File> getAllFiles(String path) {
+	public static LinkedList<File> getAllFiles(String path) {
 		return getAllFiles(new File(path));
 	}
 

--- a/src/main/java/xueli/utils/io/LinkedListSplicer.java
+++ b/src/main/java/xueli/utils/io/LinkedListSplicer.java
@@ -1,0 +1,86 @@
+package xueli.utils.io;
+
+import java.util.LinkedList;
+import java.lang.reflect.Field;
+import sun.misc.Unsafe;
+
+/**
+ * Oops, java.util.LinkedList doesn't support splice() <br />
+ * what's worse, their fields and inner classes are all private! <br />
+ * use reflection to crack them!
+ * 
+ * @author Java_Herobrine
+ * @see java.util.LinkedList.Node
+ */
+public final class LinkedListSplicer {
+	private LinkedListSplicer() {
+	}
+
+	public static final long LINKEDLIST_NODE_PREV;
+	public static final long LINKEDLIST_NODE_NEXT;
+	public static final long LINKEDLIST_NODE_ELEMENT;
+	public static final long LINKEDLIST_HEAD;
+	public static final long LINKEDLIST_TAIL;
+	public static final long LINKEDLIST_SIZE;// They are all offsets
+	private static final Unsafe UNSAFE;
+	static {
+		Class<?> clazz = LinkedList.class;
+		Class<?>[] whereNodeIsIn = clazz.getDeclaredClasses();
+		Class<?> res = void.class;
+		for (int i = 0; i < whereNodeIsIn.length; i++) {
+			if (whereNodeIsIn[i].getName().equals("java.util.LinkedList$Node")) {
+				res = whereNodeIsIn[i];
+			}
+		}
+		Field prev = null, next = null, head = null, tail = null, element = null, size = null;
+		Unsafe u = null;
+		try {
+			prev = res.getDeclaredField("prev");
+			next = res.getDeclaredField("next");
+			element = res.getDeclaredField("item");
+			tail = clazz.getDeclaredField("last");
+			head = clazz.getDeclaredField("first");
+			size = clazz.getDeclaredField("size");
+			Field unsafe = Unsafe.class.getDeclaredField("theUnsafe");
+			unsafe.setAccessible(true);
+			u = (Unsafe) unsafe.get(null);
+		} catch (Exception e) {
+		}
+		UNSAFE = u;
+		LINKEDLIST_NODE_PREV = UNSAFE.objectFieldOffset(prev);
+		LINKEDLIST_NODE_NEXT = UNSAFE.objectFieldOffset(next);
+		LINKEDLIST_NODE_ELEMENT = UNSAFE.objectFieldOffset(element);
+		LINKEDLIST_HEAD = UNSAFE.objectFieldOffset(head);
+		LINKEDLIST_TAIL = UNSAFE.objectFieldOffset(tail);
+		LINKEDLIST_SIZE = UNSAFE.objectFieldOffset(size);
+	}
+
+	/**
+	 * equivalent to l1.splice(l2) if LinkedList supports splice <br />
+	 * and l2 will be cleared
+	 * 
+	 * @param <T> type
+	 * @param l1  the first linked list
+	 * @param l2  the second linked list
+	 * @author Java_Herobrine
+	 */
+	public static <T> void splice(LinkedList<T> l1, LinkedList<T> l2) {
+		Object tail = UNSAFE.getObject(l1, LINKEDLIST_TAIL);
+		if (tail == null) {
+			UNSAFE.getAndSetObject(l1, LINKEDLIST_HEAD, UNSAFE.getObject(l2, LINKEDLIST_HEAD));
+			UNSAFE.getAndSetInt(l1, LINKEDLIST_SIZE, UNSAFE.getInt(l2, LINKEDLIST_SIZE));
+			UNSAFE.getAndSetObject(l1, LINKEDLIST_TAIL, UNSAFE.getObject(l2, LINKEDLIST_TAIL));
+			return;
+		}
+		Object head = UNSAFE.getObject(l2, LINKEDLIST_HEAD);
+		if (head == null) {
+			return;
+		}
+		UNSAFE.getAndSetObject(tail, LINKEDLIST_NODE_NEXT, head);
+		UNSAFE.getAndSetObject(head, LINKEDLIST_NODE_PREV, tail);
+		UNSAFE.getAndSetObject(l2, LINKEDLIST_HEAD, null);
+		UNSAFE.getAndSetObject(l2, LINKEDLIST_TAIL, null);
+		UNSAFE.getAndSetInt(l1, LINKEDLIST_SIZE,
+				UNSAFE.getInt(l1, LINKEDLIST_SIZE) + UNSAFE.getAndSetInt(l2, LINKEDLIST_SIZE, 0));
+	}
+}

--- a/src/main/java/xueli/utils/io/SuffixFilter.java
+++ b/src/main/java/xueli/utils/io/SuffixFilter.java
@@ -8,12 +8,12 @@ public class SuffixFilter implements FileFilter {
 	private String suffix;
 
 	public SuffixFilter(String suffix) {
-		this.suffix = suffix;
+		this.suffix = "." + suffix;
 	}
 
 	@Override
 	public boolean accept(File pathname) {
-		return pathname.getName().endsWith("." + suffix);
+		return pathname.getName().endsWith(suffix);
 	}
 
 }


### PR DESCRIPTION
### ```SuffixFilter```
The method ```accept()``` of ```SuffixFilter``` creates a temporary ```StringBuilder``` object when called, so I put ```"." + suffix``` in its constructor to avoid lots of temporary objects
### ```Files```
the method ```getAllFiles``` use ```ArrayList``` to store files.
However, it's wiser to use ```LinkedList``` to do so.Why?
Suppose an extreme situation: 
You wanna get all files of a folder like this
![image](https://github.com/user-attachments/assets/e33fa529-0fcf-48f6-a3f1-95a446ec66af)
Let's compute the time complexity.
It will divide into 2 parts, which contains half of the files, and ```addAll()``` will merge them into one ```ArrayList```
So the equation of recursion is ```T(n)=2T(n/2)+O(n)```, because the time complexity of ```addAll()``` is ```O(n)```
It's ```T(n)=O(nlogn)```, and it's exceedingly bad!!!
Similarly, if there're only few folders, the ```addAll()``` method increases the constant factor.
Using ```LinkedList.splice()``` can help with it.
However, it's not provided, and Java reflection is safer than previous versions(that's to say, I can't use reflection to directly access ```LinkedList```'s private members). So, I use ```sun.misc.Unsafe``` to implement the missing ```splice()``` method.
Also, 
```Java
if(f.isFile()){
    files.add(f);
    continue;
}
```
helps reduce temporary ```List``` object in case of tons of single files in one folder, which is common.
### ```LinkedListSplicer```
An implementation of ```splice()```.
I'm sorry that I failed to keep your code style.